### PR TITLE
Populate more metadata envelope attributes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ export CONTENT_STORE_URL=http://my-content-store.com:9000/
 export CONTENT_STORE_APIKEY="cd54a09f6593cb5b17177..."
 export CONTENT_ID_BASE=https://github.com/myorg/myrepo
 
-./deconst-preparer-jekyll.sh /path/to/control-repo
+./deconst-preparer-jekyll.sh /path/to/content-repo
 ```
 
 ### Configuration
@@ -32,3 +32,24 @@ The following values must be present in the build environment to submit assets:
  * `CONTENT_STORE_APIKEY` must be a valid API key issued by the content service. See [the content service documentation](https://github.com/deconst/content-service#post-keysnamedname) for instructions on generating an API key.
  * `CONTENT_ID_BASE` must be set to a prefix that's unique among the content repositories associated with the target deconst instance. Our convention is to use the base URL of the GitHub repository.
  * `TRAVIS_PULL_REQUEST` must be set to `"false"`. Travis automatically sets this value for your build environment on the primary branch of your repository.
+
+## Markdown integration
+
+The Deconst layout key for any Jekyll page can be controlled explicitly by setting the `deconst_layout` attribute in its frontmatter. If `deconst_layout` is not present, the page's Jekyll
+`layout` name will be used.
+
+Other frontmatter keys that have special meaning to Deconst include:
+
+ * `title`
+ * `categories`
+ * `tags`
+ * `author`
+ * `bio`
+ * `date`
+ * `disqus`. If present, this must be a dictionary containing `short_name` or `mode` subattributes:
+   * `short_name` will be used as the Disqus "short name", used to identify the associated Disqus account.
+   * `mode` must be either `count` or `embed`. If unspecified,
+
+All of these keys are optional. If present, each will be included within the metadata envelope generated for that page, and will be made available to the Handlebars templates in the control repository for rendering.
+
+`disqus_short_name` and `disqus_default_mode` may also be specified globally in the Jekyll site's `_config.yml` file. If so, Disqus attributes will be included in *all* metadata envelopes generated from this content repository. `disqus` settings present in a specific page will override the site-global settings for that page.

--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -56,14 +56,20 @@ module PreparerMD
       attr_page.call "previous"
 
       # Discus integration attributes
-      if output["disqus"]
-        short_name = output["disqus"]["short_name"] ||
-          site.config["disqus_short_name"]
+      page_disqus = output["disqus"]
+      if page_disqus || site.config["disqus_short_name"]
+        short_name = site.config["disqus_short_name"]
+        mode = site.config["disqus_default_mode"] || "embed"
+
+        if page_disqus
+          short_name = page_disqus["short_name"] if page_disqus["short_name"]
+          mode = page_disqus["mode"] if page_disqus["mode"]
+        end
 
         envelope["disqus"] = {
           include: true,
           short_name: short_name,
-          embed: output["disqus"]["mode"] != "count"
+          embed: mode == "embed"
         }
       end
 

--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -27,7 +27,7 @@ module PreparerMD
     end
 
     def render_json(page, site)
-      layout = page.data["deconst-layout"] || page.data["layout"]
+      layout = page.data["deconst_layout"] || page.data["layout"]
 
       page.data["layout"] = nil
       page.render({}, site.site_payload)

--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -53,13 +53,16 @@ module PreparerMD
       attr_plain.call "bio"
       attr_date.call "date", "publish_date"
       attr_page.call "next"
-      attr_page.call "prev"
+      attr_page.call "previous"
 
       # Discus integration attributes
       if output["disqus"]
+        short_name = output["disqus"]["short_name"] ||
+          site.config["disqus_short_name"]
+
         envelope["disqus"] = {
           include: true,
-          short_name: output["disqus"]["short_name"],
+          short_name: short_name,
           embed: output["disqus"]["mode"] != "count"
         }
       end


### PR DESCRIPTION
Most of these are related to blog post metadata.

The first Jekyll preparer bit of deconst/deconst-docs#43.
