### PR TITLE
Content Type from frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Other frontmatter keys that have special meaning to Deconst include:
  * `date`
  * `disqus`. If present, this must be a dictionary containing `short_name` or `mode` subattributes:
    * `short_name` will be used as the Disqus "short name", used to identify the associated Disqus account.
-   * `mode` must be either `count` or `embed`. If unspecified,
+   * `mode` must be either `count` or `embed`. If unspecified
+ * `content_type`
 
 All of these keys are optional. If present, each will be included within the metadata envelope generated for that page, and will be made available to the Handlebars templates in the control repository for rendering.
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Other frontmatter keys that have special meaning to Deconst include:
  * `date`
  * `disqus`. If present, this must be a dictionary containing `short_name` or `mode` subattributes:
    * `short_name` will be used as the Disqus "short name", used to identify the associated Disqus account.
-   * `mode` must be either `count` or `embed`. If unspecified
+   * `mode` must be either `count` or `embed`. If unspecified, will default to `embed`.
  * `content_type`
 
 All of these keys are optional. If present, each will be included within the metadata envelope generated for that page, and will be made available to the Handlebars templates in the control repository for rendering.

--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -66,6 +66,7 @@ module PreparerMD
         envelope[to] = { url: linked_page.url, title: linked_page.title } if linked_page
       end
 
+      attr_plain.call "content_type"
       attr_plain.call "author"
       attr_plain.call "bio"
       attr_date.call "date", "publish_date"


### PR DESCRIPTION
Allow documents (such as the RSS feed; deconst/deconst-docs#74) to set their own content-type.
