### PR TITLE
build a docker-compose stack and allow submitting a single doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+env

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,9 @@ COPY preparermd.gemspec /usr/src/app/preparermd.gemspec
 COPY lib/preparermd/version.rb /usr/src/app/lib/preparermd/version.rb
 RUN bundle install
 
+COPY . /usr/src/app
+
+VOLUME /usr/content-repo
 WORKDIR /usr/content-repo
 
 CMD ["ruby", "-I/usr/src/app/lib", "-rpreparermd", "-e", "PreparerMD.build"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,6 @@ COPY preparermd.gemspec /usr/src/app/preparermd.gemspec
 COPY lib/preparermd/version.rb /usr/src/app/lib/preparermd/version.rb
 RUN bundle install
 
-COPY . /usr/src/app
-
-VOLUME /usr/control-repo
-WORKDIR /usr/control-repo
+WORKDIR /usr/content-repo
 
 CMD ["ruby", "-I/usr/src/app/lib", "-rpreparermd", "-e", "PreparerMD.build"]

--- a/README.md
+++ b/README.md
@@ -13,16 +13,17 @@ It's intended to be used within a CI system to present content to the rest of th
 To run the Jekyll preparer locally, you'll need to install:
 
  * [Docker](https://docs.docker.com/installation/#installation) for your platform. Choose the boot2docker option for Mac OS X or Windows.
+ * [Docker Compose](https://docs.docker.com/compose/install/)
 
-Once you have Docker set up, export any desired configuration variables, run `deconst-preparer-jekyll.sh` with the path of a control repository clone to prepare the Jekyll content found there.
+Once you have Docker set up, create a copy of the file `env.example` named `env` and customize it with your Rackspace credentials, container names, local content service API Key, and path to your Jekyll repo.
 
-```bash
-export CONTENT_STORE_URL=http://my-content-store.com:9000/
-export CONTENT_STORE_APIKEY="cd54a09f6593cb5b17177..."
-export CONTENT_ID_BASE=https://github.com/myorg/myrepo
+Run the preparer to build the Jekyll site and submit content to the content service:
 
-./deconst-preparer-jekyll.sh /path/to/content-repo
 ```
+bin/submit [document-path]
+```
+
+When the `document-path` argument is provided, only that page will be submitted to the content service. This can be useful when debugging things on a large site. `document-path` should be a root-relative URL, such as `/blog/index.html`. When `document-path` is not provided, all pages and assets in the site will be submitted to the content service.
 
 ### Configuration
 

--- a/bin/submit
+++ b/bin/submit
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+IFS=$'\n\t'
+
+source ./env
+
+JEKYLL_DOCUMENT=${1:-""};
+
+JEKYLL_DOCUMENT=$JEKYLL_DOCUMENT docker-compose up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,29 @@
+---
+mongo:
+  image: mongo:2.6
+content:
+  image: quay.io/deconst/content-service
+  links:
+  - "mongo:mongo"
+  environment:
+    RACKSPACE_USERNAME:
+    RACKSPACE_APIKEY:
+    RACKSPACE_REGION:
+    ADMIN_APIKEY:
+    CONTENT_CONTAINER:
+    ASSET_CONTAINER:
+    MONGODB_URL: mongodb://mongo:27017/content
+    CONTENT_LOG_LEVEL: DEBUG
+preparer:
+    build: .
+    links:
+        - content
+    environment:
+        CONTENT_STORE_URL: http://content:8080
+        CONTENT_STORE_APIKEY:
+        CONTENT_ID_BASE:
+        TRAVIS_PULL_REQUEST: "false"
+        JEKYLL_DOCUMENT:
+    volumes:
+        - ".:/usr/src/app"
+        - "${JEKYLL_PATH}:/usr/content-repo"

--- a/env.example
+++ b/env.example
@@ -1,0 +1,23 @@
+# Copy this to "env" and fill in your secrets and customization:
+#
+# cp env.example env
+# ${EDITOR} env
+
+# Rackspace credentials.
+# These are only used for Cloud Files.
+
+export RACKSPACE_USERNAME=
+export RACKSPACE_APIKEY=
+export RACKSPACE_REGION=
+
+# Set this to something different to keep content separated in different Cloud Files containers.
+# Deconst uses two: one for CDN assets and one for metadata envelopes.
+
+export CONTENT_CONTAINER=
+export ASSET_CONTAINER=
+
+# The content service's API Key. Used for write actions.
+export ADMIN_APIKEY=
+
+# Path to your Jekyll site
+export JEKYLL_PATH=

--- a/lib/preparermd/config.rb
+++ b/lib/preparermd/config.rb
@@ -5,7 +5,7 @@ module PreparerMD
   # Configuration values and credentials read from the process' environment.
   #
   class Config
-    attr_reader :content_store_url, :content_store_apikey, :content_id_base
+    attr_reader :content_store_url, :content_store_apikey, :content_id_base, :jekyll_document
 
 
     # Create a new configuration populated with values from the environment.
@@ -14,6 +14,7 @@ module PreparerMD
       @content_store_url = ENV.fetch('CONTENT_STORE_URL', '').gsub(%r{/\Z}, '')
       @content_store_apikey = ENV.fetch('CONTENT_STORE_APIKEY', '')
       @content_id_base = ENV.fetch('CONTENT_ID_BASE', '').gsub(%r{/\Z}, '')
+      @jekyll_document = ENV.fetch('JEKYLL_DOCUMENT', '')
     end
 
     def load_from(f)

--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -27,6 +27,11 @@ module PreparerMD
     end
 
     def render_json(page, site)
+
+      if PreparerMD.config.jekyll_document != '' and PreparerMD.config.jekyll_document != Jekyll::URL.unescape_path(page.url)
+        return 0
+      end
+
       layout = page.data["deconst_layout"] || page.data["layout"]
 
       global_tags = site.config["deconst_tags"] || []


### PR DESCRIPTION
@smashwilson :eyes: requested.

I had to put this into docker-compose because I couldn't figure out a better way to quickly test my changes. Since the last time I worked on this, my Ruby install has mysteriously killed itself, so running it directly on my machine just wasn't going to work.

Notably, I've added an option to build the entire site but only submit a single content document. It's pretty ugly.
