### PR TITLE
Process/Submit documents within collections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ruby:2.2.2
 MAINTAINER Ash Wilson <ash.wilson@rackspace.com>
 
-RUN mkdir -p /usr/src/app /usr/control-repo
+RUN mkdir -p /usr/src/app /usr/content-repo
 
 WORKDIR /usr/src/app
 COPY Gemfile /usr/src/app/Gemfile


### PR DESCRIPTION
Collections are annoyingly different from pages/posts. This allows the preparer to build/submit pages, posts, and collection documents all at once!
