### PR TITLE
Fix the broken blog build

### DIFF
--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -41,7 +41,7 @@ module PreparerMD
       # Is this a page/post, or a collection item?
       # This is probably not a conclusive test
       is_post = document.respond_to?('render')
-
+      envelope = {}
       global_tags = site.config["deconst_tags"] || []
       global_post_tags = site.config["deconst_post_tags"] || []
       global_page_tags = site.config["deconst_page_tags"] || []


### PR DESCRIPTION
The blog build was not working because of an unset local variable exception. This just drops in a default value for to avoid the exception.
