### PR TITLE
Use an Alpine base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
-FROM ruby:2.2.2
+FROM alpine:3.2
 MAINTAINER Ash Wilson <ash.wilson@rackspace.com>
+
+RUN apk add --update ruby ruby-json ruby-dev git build-base libffi-dev nodejs python \
+  && rm -rf /var/cache/apk/* \
+  && rm -rf /usr/share/ri
+RUN gem install bundler --no-rdoc --no-ri
 
 RUN mkdir -p /usr/src/app /usr/content-repo
 


### PR DESCRIPTION
The same deal as deconst/preparer-sphinx#38. It's not _quite_ as dramatic here, but still well worth it:

```
$ docker images
REPOSITORY          TAG                 IMAGE ID            CREATED              VIRTUAL SIZE
after               latest              a9589042d19e        About a minute ago   302.9 MB
before              latest              77c5086da700        38 minutes ago       823.9 MB
```

We'll likely get even more benefit once we move to Jekyll 3 and can :hocho: Node and Python.
