### PR TITLE
Allow users to disable TLS verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ The following values must be present in the build environment to submit assets:
 
  * `CONTENT_STORE_URL` must be the base URL of the publicly available content store service. The prepare script defaults this to one consistent with our docker-compose setups.
  * `CONTENT_STORE_APIKEY` must be a valid API key issued by the content service. See [the content service documentation](https://github.com/deconst/content-service#post-keysnamedname) for instructions on generating an API key.
+ * `CONTENT_STORE_TLS_VERIFY` may be set to `"false"` to disable certificate verification. 🚨 *Only use this feature for development and local clusters with self-signed certificates. It defeats a lot of the point of encrypting traffic.* 🚨
  * `CONTENT_ID_BASE` must be set to a prefix that's unique among the content repositories associated with the target deconst instance. Our convention is to use the base URL of the GitHub repository.
  * `TRAVIS_PULL_REQUEST` must be set to `"false"`. Travis automatically sets this value for your build environment on the primary branch of your repository.
 

--- a/lib/preparermd/config.rb
+++ b/lib/preparermd/config.rb
@@ -5,7 +5,8 @@ module PreparerMD
   # Configuration values and credentials read from the process' environment.
   #
   class Config
-    attr_reader :content_store_url, :content_store_apikey, :content_id_base, :jekyll_document
+    attr_reader :content_store_url, :content_store_apikey, :content_store_tls_verify
+    attr_reader :content_id_base, :jekyll_document
 
 
     # Create a new configuration populated with values from the environment.
@@ -13,6 +14,7 @@ module PreparerMD
     def initialize
       @content_store_url = ENV.fetch('CONTENT_STORE_URL', '').gsub(%r{/\Z}, '')
       @content_store_apikey = ENV.fetch('CONTENT_STORE_APIKEY', '')
+      @content_store_tls_verify = ENV.fetch('CONTENT_STORE_TLS_VERIFY', 'true') == 'false'
       @content_id_base = ENV.fetch('CONTENT_ID_BASE', '').gsub(%r{/\Z}, '')
       @jekyll_document = ENV.fetch('JEKYLL_DOCUMENT', '')
     end

--- a/lib/preparermd/config.rb
+++ b/lib/preparermd/config.rb
@@ -61,6 +61,12 @@ module PreparerMD
         reasons << "This looks like a pull request build on Travis."
       end
 
+      unless @content_store_tls_verify
+        $stderr.puts
+        $stderr.puts "TLS certificate verification disabled!"
+        $stderr.puts
+      end
+
       if reasons.empty?
         puts "Content will be submitted to the content service."
 

--- a/lib/preparermd/config.rb
+++ b/lib/preparermd/config.rb
@@ -14,7 +14,8 @@ module PreparerMD
     def initialize
       @content_store_url = ENV.fetch('CONTENT_STORE_URL', '').gsub(%r{/\Z}, '')
       @content_store_apikey = ENV.fetch('CONTENT_STORE_APIKEY', '')
-      @content_store_tls_verify = ENV.fetch('CONTENT_STORE_TLS_VERIFY', 'true') == 'false'
+      @content_store_tls_verify = ENV.fetch('CONTENT_STORE_TLS_VERIFY', '') != 'false'
+
       @content_id_base = ENV.fetch('CONTENT_ID_BASE', '').gsub(%r{/\Z}, '')
       @jekyll_document = ENV.fetch('JEKYLL_DOCUMENT', '')
     end

--- a/lib/preparermd/overrides/environment.rb
+++ b/lib/preparermd/overrides/environment.rb
@@ -18,7 +18,9 @@ class Index < Sprockets::Index
   def initialize(*args)
     super
 
-    @conn = Faraday.new(url: PreparerMD.config.content_store_url) do |conn|
+    opts = {url: PreparerMD.config.content_store_url}
+    opts[:ssl] = {verify: false} if !PreparerMD.config.content_store_tls_verify
+    @conn = Faraday.new(opts) do |conn|
       conn.request :retry, max: 3, methods: [:post]
       conn.request :multipart
       conn.response :raise_error

--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -10,7 +10,10 @@ module PreparerMD
 
     def generate(site)
       if PreparerMD.config.should_submit?
-        @conn = Faraday.new(url: PreparerMD.config.content_store_url) do |conn|
+        opts = {url: PreparerMD.config.content_store_url}
+        opts[:ssl] = {verify: false} if !PreparerMD.config.content_store_tls_verify
+
+        @conn = Faraday.new(opts) do |conn|
           conn.request :retry, max: 3, methods: [:put]
           conn.response :raise_error
 


### PR DESCRIPTION
Like the Sphinx preparer, disable TLS certificate verification if `CONTENT_STORE_TLS_VERIFY` is set to `"false"`.

Fixes deconst/deconst-docs#198.
