### PR TITLE
Unsearchable

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,14 @@ Other frontmatter keys that have special meaning to Deconst include:
    * `short_name` will be used as the Disqus "short name", used to identify the associated Disqus account.
    * `mode` must be either `count` or `embed`. If unspecified, will default to `embed`.
  * `content_type`
+ * `unsearchable` may be `true` to exclude this document from full-text search indexing.
 
 All of these keys are optional. If present, each will be included within the metadata envelope generated for that page, and will be made available to the Handlebars templates in the control repository for rendering.
+
+Some keys may be set globally for the repository in your `_config.yml` file:
+
+ * `deconst_default_unsearchable` will set the default value of `unsearchable` for all documents.
+ * `deconst_tags` specifies tags that should be set on *all* documents within this repository. Tags listed here will be merged with tags specified on individual documents.
+ * `deconst_post_tags` is similar, but only for blog posts (in `_posts/`). `deconst_page_tags` applies to non-posts instead.
 
 `disqus_short_name` and `disqus_default_mode` may also be specified globally in the Jekyll site's `_config.yml` file. If so, Disqus attributes will be included in *all* metadata envelopes generated from this content repository. `disqus` settings present in a specific page will override the site-global settings for that page.

--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -113,6 +113,10 @@ module PreparerMD
           []
         end)
 
+      unless global_unsearchable.nil? || envelope.has_key?("unsearchable")
+        envelope["unsearchable"] = global_unsearchable
+      end
+
       envelope["tags"] = tags.to_a
 
       # Discus integration attributes

--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -48,6 +48,7 @@ module PreparerMD
       global_tags = site.config["deconst_tags"] || []
       global_post_tags = site.config["deconst_post_tags"] || []
       global_page_tags = site.config["deconst_page_tags"] || []
+      global_unsearchable = site.config["deconst_default_unsearchable"]
 
       attr_plain = ->(document, from, to = from) { envelope[to] = document[from] if document[from] }
       attr_date = ->(document, from, to = from) { envelope[to] = document[from].rfc2822 if document[from] }
@@ -77,6 +78,7 @@ module PreparerMD
         attr_page.call liquid, "next"
         attr_page.call liquid, "previous"
         attr_plain.call liquid, "queries"
+        attr_plain.call liquid, "unsearchable"
 
         tags = Set.new(liquid["tags"] || [])
         page_disqus = liquid["disqus"]
@@ -95,6 +97,7 @@ module PreparerMD
         attr_page.call document.data, "next"
         attr_page.call document.data, "previous"
         attr_plain.call document.data, "queries"
+        attr_plain.call document.data, "unsearchable"
 
         tags = Set.new(document.data['tags'] || [])
         page_disqus = document.data["disqus"]

--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -50,7 +50,7 @@ module PreparerMD
       global_page_tags = site.config["deconst_page_tags"] || []
       global_unsearchable = site.config["deconst_default_unsearchable"]
 
-      attr_plain = ->(document, from, to = from) { envelope[to] = document[from] if document[from] }
+      attr_plain = ->(document, from, to = from) { envelope[to] = document[from] unless document[from].nil? }
       attr_date = ->(document, from, to = from) { envelope[to] = document[from].rfc2822 if document[from] }
       attr_page = ->(document, from, to = from) do
         linked_page = document[from]

--- a/test/envelopes/dest/idbase%2Fmaximum
+++ b/test/envelopes/dest/idbase%2Fmaximum
@@ -1,1 +1,37 @@
-{"title":"the page title","body":"<h1 id=\"maximum-markdown-document\">Maximum markdown document</h1>\n\n<p>This is a Markdown document that contains an example of each frontmatter key that may be present in a non-Post document that has significance to Deconst.</p>\n","categories":["cat one","cat two"],"meta":{"title":"the page title","categories":["cat one","cat two"],"tags":["tag one","tag two"],"unrecognized":"an arbitrary other frontmatter key","content_type":"text/html","author":"ME","bio":"the author's bio","date":"2015-11-20","publish_date":"2015-11-21","deconst_layout":"the layout key","layout":null},"content_type":"text/html","author":"ME","bio":"the author's bio","publish_date":"Fri, 20 Nov 2015 00:00:00 +0000","tags":["tag one","tag two"]}
+{
+  "title": "the page title",
+  "body": "<h1 id=\"maximum-markdown-document\">Maximum markdown document</h1>\n\n<p>This is a Markdown document that contains an example of each frontmatter key that may be present in a non-Post document that has significance to Deconst.</p>\n",
+  "categories": [
+    "cat one",
+    "cat two"
+  ],
+  "meta": {
+    "title": "the page title",
+    "categories": [
+      "cat one",
+      "cat two"
+    ],
+    "tags": [
+      "tag one",
+      "tag two"
+    ],
+    "unrecognized": "an arbitrary other frontmatter key",
+    "content_type": "text/html",
+    "author": "ME",
+    "bio": "the author's bio",
+    "date": "2015-11-20",
+    "publish_date": "2015-11-21",
+    "deconst_layout": "the layout key",
+    "layout": null,
+    "unsearchable": true
+  },
+  "content_type": "text/html",
+  "author": "ME",
+  "bio": "the author's bio",
+  "publish_date": "Fri, 20 Nov 2015 00:00:00 +0000",
+  "tags": [
+    "tag one",
+    "tag two"
+  ],
+  "unsearchable": true
+}

--- a/test/envelopes/src/maximum.md
+++ b/test/envelopes/src/maximum.md
@@ -12,6 +12,7 @@ author: ME
 bio: the author's bio
 date: 2015-11-20
 publish_date: 2015-11-21
+unsearchable: true
 deconst_layout: the layout key
 ---
 


### PR DESCRIPTION
Allow content to be marked as `unsearchable`.

References deconst/content-service#63 and deconst/deconst-docs#187.
