### PR TITLE
Optionally accept a CONTENT_ROOT.

### DIFF
--- a/lib/preparermd.rb
+++ b/lib/preparermd.rb
@@ -14,8 +14,20 @@ module PreparerMD
 
   # Primary entry point for the site build. Execute a Jekyll build with customized options.
   #
-  def self.build(source = Dir.pwd, destination = File.join(Dir.pwd, '_site'))
+  def self.build(source = nil, destination = nil)
     @config = Config.new
+
+    if @config.has_content_root?
+      if ! source.nil? && source != @config.content_root
+        puts "Warning: Overriding CONTENT_ROOT [#{@config.content_root}] with argument [#{source}]."
+      else
+        Dir.chdir @config.content_root
+        source = @config.content_root
+      end
+    else
+      source ||= Dir.pwd
+    end
+    destination ||= File.join(source, '_site')
 
     config_path = File.join(source, "_deconst.json")
     if File.exist?(config_path)

--- a/lib/preparermd/config.rb
+++ b/lib/preparermd/config.rb
@@ -5,6 +5,7 @@ module PreparerMD
   # Configuration values and credentials read from the process' environment.
   #
   class Config
+    attr_reader :content_root
     attr_reader :content_store_url, :content_store_apikey, :content_store_tls_verify
     attr_reader :content_id_base, :jekyll_document, :github_url, :github_branch, :meta
 
@@ -12,12 +13,18 @@ module PreparerMD
     # Create a new configuration populated with values from the environment.
     #
     def initialize
+      @content_root = ENV.fetch('CONTENT_ROOT', '')
+
       @content_store_url = ENV.fetch('CONTENT_STORE_URL', '').gsub(%r{/\Z}, '')
       @content_store_apikey = ENV.fetch('CONTENT_STORE_APIKEY', '')
       @content_store_tls_verify = ENV.fetch('CONTENT_STORE_TLS_VERIFY', '') != 'false'
 
       @content_id_base = ENV.fetch('CONTENT_ID_BASE', '').gsub(%r{/\Z}, '')
       @jekyll_document = ENV.fetch('JEKYLL_DOCUMENT', '')
+    end
+
+    def has_content_root?
+      ! @content_root.empty?
     end
 
     def load_from(f)


### PR DESCRIPTION
Accept a `CONTENT_ROOT` environment variable to prepare content from paths other than the cwd, notable `--volumes-from` mounted paths.

In service of deconst/strider-deconst-content#3.
