### PR TITLE
Use a non-root user within the preparer container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM alpine:3.2
+FROM alpine:3.3
 MAINTAINER Ash Wilson <ash.wilson@rackspace.com>
 
-RUN apk add --update ruby ruby-json ruby-dev git build-base libffi-dev nodejs python \
-  && rm -rf /var/cache/apk/* \
+RUN apk add --no-cache ruby ruby-json ruby-dev git build-base libffi-dev nodejs python \
   && rm -rf /usr/share/ri
 RUN gem install bundler --no-rdoc --no-ri
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,21 @@
 FROM alpine:3.3
 MAINTAINER Ash Wilson <ash.wilson@rackspace.com>
 
-RUN apk add --no-cache ruby ruby-json ruby-dev git build-base libffi-dev nodejs python \
-  && rm -rf /usr/share/ri
-RUN gem install bundler --no-rdoc --no-ri
+RUN apk add --no-cache ruby ruby-io-console ruby-irb ruby-rdoc ruby-dev \
+  git build-base libffi-dev nodejs python
 
+RUN adduser -D -g "" -u 1000 preparer
 RUN mkdir -p /usr/src/app /usr/content-repo
+RUN chown -R preparer:preparer /usr/src/app
+
+USER preparer
 
 WORKDIR /usr/src/app
+ENV GEM_HOME /usr/src/app/.gems
+ENV PATH ${PATH}:/usr/src/app/.gems/bin
+
+RUN gem install bundler --no-rdoc --no-ri
+
 COPY Gemfile /usr/src/app/Gemfile
 COPY Gemfile.lock /usr/src/app/Gemfile.lock
 COPY preparermd.gemspec /usr/src/app/preparermd.gemspec


### PR DESCRIPTION
Bump to the latest Alpine image. Create and use a non-root user for the preparer container.

Kind of a hack: the `docker` user within the `docker-machine` VM has UID 1000 and owns all files within volume-mounted directories. I'm using the same UID for the preparer user so that `docker run -v` still works (and therefore the local client).
