### PR TITLE
Escape HTML-escaped characters in asset names.

### DIFF
--- a/lib/preparermd/overrides/environment.rb
+++ b/lib/preparermd/overrides/environment.rb
@@ -68,7 +68,7 @@ class Index < Sprockets::Index
         FileUtils.cp asset.pathname.to_s, dest
 
         asset.extend PreparerMD::AssetPatch
-        asset.asset_render_url = "__deconst-asset:#{URI.escape asset.logical_path, '%_'}__"
+        asset.asset_render_url = "__deconst-asset:#{URI.escape asset.logical_path, '%_&"<>'}__"
 
         puts "ok"
       end


### PR DESCRIPTION
This prevents weirdness when asset filenames contain characters that are ordinarily escaped in HTML output, like `&`. (Yes, we have files like this.)
