### PR TITLE
Remove now-unused code

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Build Status](https://travis-ci.org/deconst/preparer-jekyll.svg?branch=master)](https://travis-ci.org/deconst/preparer-jekyll)
 [![Docker Repository on Quay.io](https://quay.io/repository/deconst/preparer-jekyll/status "Docker Repository on Quay.io")](https://quay.io/repository/deconst/preparer-jekyll)
 
-*preparermd* builds each page of a [Jekyll site](http://jekyllrb.com/) into custom JSON metadata envelopes and broadcasts them to a [content service](https://github.com/deconst/content-service) that performs storage and indexing for presentation and search.
+*deconst-preparer-jekyll* builds each page of a [Jekyll site](http://jekyllrb.com/) into custom JSON metadata envelopes and broadcasts them to a [content service](https://github.com/deconst/content-service) that performs storage and indexing for presentation and search.
 
 It's intended to be used within a CI system to present content to the rest of the build pipeline.
 
@@ -30,9 +30,8 @@ When the `document-path` argument is provided, only that page will be submitted 
 
 The following values must be present in the build environment to submit assets:
 
- * `CONTENT_STORE_URL` must be the base URL of the publicly available content store service. The prepare script defaults this to one consistent with our docker-compose setups.
- * `CONTENT_STORE_APIKEY` must be a valid API key issued by the content service. See [the content service documentation](https://github.com/deconst/content-service#post-keysnamedname) for instructions on generating an API key.
- * `CONTENT_STORE_TLS_VERIFY` may be set to `"false"` to disable certificate verification. 🚨 *Only use this feature for development and local clusters with self-signed certificates. It defeats a lot of the point of encrypting traffic.* 🚨
+ * `ENVELOPE_DIR` must be set to a directory that metadata envelopes should be written to.
+ * `ASSET_DIR` must be set to a directory that assets should be written to.
  * `CONTENT_ID_BASE` must be set to a prefix that's unique among the content repositories associated with the target deconst instance. Our convention is to use the base URL of the GitHub repository.
  * `TRAVIS_PULL_REQUEST` must be set to `"false"`. Travis automatically sets this value for your build environment on the primary branch of your repository.
 

--- a/lib/preparermd/config.rb
+++ b/lib/preparermd/config.rb
@@ -8,9 +8,6 @@ module PreparerMD
     attr_reader :content_root, :envelope_dir, :asset_dir
     attr_reader :content_id_base, :jekyll_document, :github_url, :github_branch, :meta
 
-    # To deprecate
-    attr_reader :content_store_url, :content_store_apikey, :content_store_tls_verify
-
 
     # Create a new configuration populated with values from the environment.
     #
@@ -18,11 +15,6 @@ module PreparerMD
       @content_root = ENV.fetch('CONTENT_ROOT', '')
       @envelope_dir = ENV.fetch('ENVELOPE_DIR', File.join(Dir.pwd, '_site', 'deconst-envelopes'))
       @asset_dir = ENV.fetch('ASSET_DIR', File.join(Dir.pwd, '_site', 'deconst-assets'))
-
-      # To deprecate
-      @content_store_url = ENV.fetch('CONTENT_STORE_URL', '').gsub(%r{/\Z}, '')
-      @content_store_apikey = ENV.fetch('CONTENT_STORE_APIKEY', '')
-      @content_store_tls_verify = ENV.fetch('CONTENT_STORE_TLS_VERIFY', '') != 'false'
 
       @content_id_base = ENV.fetch('CONTENT_ID_BASE', '').gsub(%r{/\Z}, '')
       @jekyll_document = ENV.fetch('JEKYLL_DOCUMENT', '')
@@ -65,35 +57,14 @@ module PreparerMD
       end
     end
 
-    # Determine and report (to stderr) whether or not we have enough information to submit to the
-    # content service.
+    # Determine and report (to stderr) whether or not we have enough information to prepare.
     #
     def validate
       reasons = []
 
-      if @content_store_url.empty?
-        reasons << "CONTENT_STORE_URL is missing. It should be the base URL of the content " \
-          "storage service."
-      end
-
-      if @content_store_apikey.empty?
-        reasons << "CONTENT_STORE_APIKEY is missing. It should be a valid API key issued by the " \
-          "content service."
-      end
-
       if @content_id_base.empty?
         reasons << "CONTENT_ID_BASE is missing. It should be the common prefix used to generate " \
           "IDs for content within this repository."
-      end
-
-      if ENV['TRAVIS_PULL_REQUEST'] != "false"
-        reasons << "This looks like a pull request build on Travis."
-      end
-
-      unless @content_store_tls_verify
-        $stderr.puts
-        $stderr.puts "TLS certificate verification disabled!"
-        $stderr.puts
       end
 
       if reasons.empty?
@@ -108,14 +79,6 @@ module PreparerMD
 
         @should_submit = false
       end
-    end
-
-    # Determine whether or not we have enough information to submit to the content service.
-    #
-    def should_submit?
-      raise "#validate must be called first!" if @should_submit.nil?
-
-      @should_submit
     end
   end
 


### PR DESCRIPTION
Remove all references to content submission during preparation now that that responsibility belongs to the submitter.

Fixes #34.
