### PR TITLE
Respect the VERBOSE variable.

### DIFF
--- a/lib/preparermd.rb
+++ b/lib/preparermd.rb
@@ -41,7 +41,7 @@ module PreparerMD
       Bundler::CLI::Install.new({}).run
     end
 
-    puts "Building and submitting content."
+    puts "Preparing content."
     Jekyll::Commands::Build.process({source: source, destination: destination})
   end
 

--- a/lib/preparermd/config.rb
+++ b/lib/preparermd/config.rb
@@ -5,7 +5,7 @@ module PreparerMD
   # Configuration values and credentials read from the process' environment.
   #
   class Config
-    attr_reader :content_root, :envelope_dir, :asset_dir
+    attr_reader :content_root, :envelope_dir, :asset_dir, :verbose
     attr_reader :content_id_base, :jekyll_document, :github_url, :github_branch, :meta
 
 
@@ -15,6 +15,7 @@ module PreparerMD
       @content_root = ENV.fetch('CONTENT_ROOT', '')
       @envelope_dir = ENV.fetch('ENVELOPE_DIR', File.join(Dir.pwd, '_site', 'deconst-envelopes'))
       @asset_dir = ENV.fetch('ASSET_DIR', File.join(Dir.pwd, '_site', 'deconst-assets'))
+      @verbose = ENV.fetch('VERBOSE', '') != ''
 
       @content_id_base = ENV.fetch('CONTENT_ID_BASE', '').gsub(%r{/\Z}, '')
       @jekyll_document = ENV.fetch('JEKYLL_DOCUMENT', '')
@@ -67,12 +68,8 @@ module PreparerMD
           "IDs for content within this repository."
       end
 
-      if reasons.empty?
-        puts "Content will be submitted to the content service."
-
-        @should_submit = true
-      else
-        $stderr.puts "Not submitting content to the content service because:"
+      unless reasons.empty?
+        $stderr.puts "Unable to prepare content because:"
         $stderr.puts
         $stderr.puts reasons.map { |r| " * #{r}\n"}.join
         $stderr.puts

--- a/lib/preparermd/overrides/environment.rb
+++ b/lib/preparermd/overrides/environment.rb
@@ -19,8 +19,11 @@ class Index < Sprockets::Index
   def build_asset(path, pathname, options)
     super.tap do |asset|
       dest = File.join(PreparerMD.config.asset_dir, asset.logical_path)
-      print "Copying content asset: [#{asset.pathname}] .. "
-      $stdout.flush
+
+      if PreparerMD.config.verbose
+        print "Copying content asset: [#{asset.pathname}] .. "
+        $stdout.flush
+      end
 
       FileUtils.mkdir_p File.dirname(dest)
       FileUtils.cp asset.pathname.to_s, dest
@@ -28,7 +31,7 @@ class Index < Sprockets::Index
       asset.extend PreparerMD::AssetPatch
       asset.asset_render_url = "__deconst-asset:#{URI.escape asset.logical_path, '%_&"<>'}__"
 
-      puts "ok"
+      puts "ok" if PreparerMD.config.verbose
     end
   end
 end

--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -10,6 +10,8 @@ module PreparerMD
   class JSONGenerator < Jekyll::Generator
 
     def generate(site)
+      @config = PreparerMD.config
+
       site.collections.each do |label, collection|
         collection.docs.each do |document|
           render_json(document, site)
@@ -132,15 +134,15 @@ module PreparerMD
         }
       end
 
-      meta = PreparerMD.config.meta
+      meta = @config.meta
       meta = meta.merge(document.data.dup)
 
-      if PreparerMD.config.github_url
+      if @config.github_url
         # Hope Github doesn't change this URL
         edit_url_segments = [
-          PreparerMD.config.github_url,
+          @config.github_url,
           "edit",
-          PreparerMD.config.github_branch,
+          @config.github_branch,
           document.relative_path
         ]
 
@@ -166,9 +168,7 @@ module PreparerMD
     end
 
     def render_json(document, site)
-      if PreparerMD.config.jekyll_document != '' and PreparerMD.config.jekyll_document != Jekyll::URL.unescape_path(document.url)
-        return
-      end
+      return if @config.jekyll_document != '' and @config.jekyll_document != Jekyll::URL.unescape_path(document.url)
 
       envelope = envelope_from_document(document, site)
 
@@ -178,12 +178,14 @@ module PreparerMD
 
       path = File.join(site.dest, CGI.escape(content_id) + '.json')
 
-      print "Writing envelope: [#{path}] .. "
-      $stdout.flush
+      if @config.verbose
+        print "Writing envelope: [#{path}] .. "
+        $stdout.flush
+      end
 
       FileUtils.mkdir_p(File.dirname(path))
       File.open(path, 'w') { |f| f.write(envelope.to_json) }
-      puts "ok"
+      puts "ok" if @config.verbose
     end
 
   end


### PR DESCRIPTION
Only produce page-by-page output if `VERBOSE` is populated.
