### PR TITLE
Don't trim .json from envelope names.

### DIFF
--- a/lib/preparermd/plugins/metadata_envelopes.rb
+++ b/lib/preparermd/plugins/metadata_envelopes.rb
@@ -174,7 +174,7 @@ module PreparerMD
 
       base = PreparerMD.config.content_id_base
       content_id = File.join(base, Jekyll::URL.unescape_path(document.url))
-      content_id.gsub! %r{/*(index)?(\.html|\.json)?\Z}, ""
+      content_id.gsub! %r{/*(index)?(\.html)?\Z}, ""
 
       path = File.join(site.dest, CGI.escape(content_id) + '.json')
 


### PR DESCRIPTION
This was easier than I thought. Trim `index.html` but leave any other extensions as-is (including `.xml` and so on which were already being handled correctly).

Fixes #43.
